### PR TITLE
add back rake and Rakefile

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,3 +1,4 @@
 ---
 BUNDLE_CACHE_PATH: "vendor/gems"
 BUNDLE_PATH: "vendor/gems"
+BUNDLE_BIN: "bin"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /coverage/
 /vendor/gems
+/pkg
+/bin
 
 # rspec failure tracking
 .rspec_status

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "irb", "~> 1.14", :group => :development
+gem "rake", "~> 13.2", :group => :development
 gem "rspec", "~> 3.0", group: :development
 gem "rubocop", "~> 1.21", group: :development
 gem "simplecov", "~> 0.22.0", group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
       stringio
     racc (1.8.1)
     rainbow (3.1.1)
+    rake (13.2.1)
     rdoc (6.7.0)
       psych (>= 4.0.0)
     regexp_parser (2.9.2)
@@ -72,6 +73,7 @@ PLATFORMS
 DEPENDENCIES
   ambient-ruby-client!
   irb (~> 1.14)
+  rake (~> 13.2)
   rspec (~> 3.0)
   rubocop (~> 1.21)
   simplecov (~> 0.22.0)

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require "bundler/gem_tasks"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -9,3 +9,4 @@ cd "$(dirname "$0")/.."
 
 echo "==> Installing gem dependencies…"
 bundle install
+bundle binstubs --all


### PR DESCRIPTION
This PR adds back the rake gem and a Rakefile because I didn't realize it was including the bundler's gem-related tasks that we need to publish the gem to rubygems.org.