### PR TITLE
trying to get the gem to be pushed to rubygems.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
-# 0.1.0
+# 0.1.1
 The initial version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ambient-ruby-client (0.1.0)
+    ambient-ruby-client (0.1.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ambient
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
This pull request includes a version update for the `Ambient` module. The changes update the version number from `0.1.0` to `0.1.1`.

Version update:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL1-R1): Updated version number from `0.1.0` to `0.1.1`.
* [`lib/version.rb`](diffhunk://#diff-6ee8c614c5cd12d219c46e6e640b2bbf0fcf28505c02b0355753486c21e95897L4-R4): Updated `VERSION` constant from `0.1.0` to `0.1.1`.